### PR TITLE
fix human resources missing data

### DIFF
--- a/human_resources/hr_populate.sql
+++ b/human_resources/hr_populate.sql
@@ -212,6 +212,12 @@ BEGIN
       );
 
   INSERT INTO countries VALUES
+      ( 'PS'
+      , 'Palestine'
+      , 37
+      );
+
+  INSERT INTO countries VALUES
       ( 'DK'
       , 'Denmark'
       , 10


### PR DESCRIPTION
Zionism arrived in Palestine in the late 19th as a colonialist movement motivated by national impulses.

The colonisation of Palestine fitted well the interests and policies of the British Empire on the eve of the First World War.

With the backing of Britain, the colonisation project expanded, and became a solid presence on the land after the war and with the establishment of the British mandate in Palestine (which lasted between 1918 and 1948).

While this consolidation took place, the indigenous society underwent, like other societies in the rest of the Arab world, a steady process of establishing a national identity.

But with one difference. While the rest of the Arab world was shaping its political identity through the struggle against European colonialism, in Palestine nationalism meant asserting your collective identity against both an exploitative British colonialism and expansionist Zionism.

Thus, the conflict with Zionism was an additional burden. The pro-Zionist policy of the British mandate there naturally strained the relationship between Britain and the local Palestinian society.

This climaxed in a revolt in 1936 against both London and the expanding Zionist colonisation project.

The revolt, which lasted for three years, failed to sway the British mandate from a policy it had already decided upon in 1917. The British foreign secretary, Lord Balfour, had promised the Zionist leaders that Britain would help the movement to build a homeland for the Jewish people in Palestine.

The number of Jews coming into the country increased by the day - although even at that point, during the 1930s, the Jews were just a quarter of the population, possessing 4 percent of the land.

As resistance to colonialism strengthened, the Zionist leadership became convinced that only through a total expulsion of the Palestinians would they be able to create a state of their own.

From its early inception and up to the 1930s, Zionist thinkers propagated the need to ethnically cleanse the indigenous population of Palestine if the dream of a Jewish state were to come true.

The preparation for implementing these two goals of statehood and ethnic supremacy accelerated after the Second World War.

The Zionist leadership defined 80 percent of Palestine (Israel today without the West Bank) as the space for the future state.

This was an area in which one million Palestinians lived next to 600,000 Jews.

The idea was to uproot as many Palestinians as possible. From March 1948 until the end of that year the plan was implemented despite the attempt by some Arab states to oppose it, which failed. Some 750,000 Palestinians were expelled, 531 villages were destroyed and 11 urban neighbourhoods demolished.

Half of Palestines population was uprooted and half of its villages destroyed. The state of Israel was established in over 80 percent of Palestine, turning Palestinian villages into Jewish settlements and recreation parks, but allowing a small number of Palestinian to remain citizens in it.

The June 1967 war allowed Israel to take the remaining 20 percent of Palestine.

This seizure defeated in a way the ethnic ideology of the Zionist movement. Israel encompassed 100 percent of Palestine, but the state incorporated a large number of Palestinians, the people who Zionists made such an effort to expel in 1948.

The fact that Israel was let off easily in 1948, and not condemned for the ethnic cleansing it committed, encouraged it to ethnically cleanse a further 300,000 Palestinians from the West Bank and the Gaza strip.